### PR TITLE
[MakeXxdFix]: Fix typo in make-xxd.

### DIFF
--- a/scripts/make-xxd
+++ b/scripts/make-xxd
@@ -51,8 +51,8 @@ do_preamble() {
 
     cat >${file} <<EOF
 #pragma once
-#ifndef __rsrcource_${symbol}__
-#define __rsrcource_${symbol}__
+#ifndef __resource_${symbol}__
+#define __resource_${symbol}__
 
 EOF
 }

--- a/src/resources/cli/banner.h
+++ b/src/resources/cli/banner.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __rsrcource_banner_h__
-#define __rsrcource_banner_h__
+#ifndef __resource_banner_h__
+#define __resource_banner_h__
 
 const unsigned char res_cli_banner[] = {
   0x43, 0x6f, 0x70, 0x79, 0x72, 0x69, 0x67, 0x68, 0x74, 0x20, 0x28, 0x43,

--- a/src/resources/gui/authors.h
+++ b/src/resources/gui/authors.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __rsrcource_authors_h__
-#define __rsrcource_authors_h__
+#ifndef __resource_authors_h__
+#define __resource_authors_h__
 
 const unsigned char res_gui_authors[] = {
   0x6f, 0x72, 0x69, 0x67, 0x69, 0x6e, 0x61, 0x6c, 0x20, 0x61, 0x75, 0x74,

--- a/src/resources/gui/gpl_banner.h
+++ b/src/resources/gui/gpl_banner.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __rsrcource_gpl_banner_h__
-#define __rsrcource_gpl_banner_h__
+#ifndef __resource_gpl_banner_h__
+#define __resource_gpl_banner_h__
 
 const unsigned char res_gui_gpl_banner[] = {
   0x3c, 0x68, 0x74, 0x6d, 0x6c, 0x3e, 0x0a, 0x3c, 0x68, 0x65, 0x61, 0x64,

--- a/src/resources/help.h
+++ b/src/resources/help.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __rsrcource_help_h__
-#define __rsrcource_help_h__
+#ifndef __resource_help_h__
+#define __resource_help_h__
 
 #include "help/create.h"
 #include "help/debug.h"

--- a/src/resources/help/create.h
+++ b/src/resources/help/create.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __rsrcource_create_h__
-#define __rsrcource_create_h__
+#ifndef __resource_create_h__
+#define __resource_create_h__
 
 const unsigned char res_help_create[] = {
   0x49, 0x66, 0x20, 0x74, 0x68, 0x69, 0x73, 0x20, 0x66, 0x6c, 0x61, 0x67,

--- a/src/resources/help/debug.h
+++ b/src/resources/help/debug.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __rsrcource_debug_h__
-#define __rsrcource_debug_h__
+#ifndef __resource_debug_h__
+#define __resource_debug_h__
 
 const unsigned char res_help_debug[] = {
   0x45, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x20, 0x64, 0x65, 0x62, 0x75, 0x67,

--- a/src/resources/help/format.h
+++ b/src/resources/help/format.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __rsrcource_format_h__
-#define __rsrcource_format_h__
+#ifndef __resource_format_h__
+#define __resource_format_h__
 
 const unsigned char res_help_format[] = {
   0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x20, 0x6e, 0x75, 0x6d, 0x62,

--- a/src/resources/help/groups.h
+++ b/src/resources/help/groups.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __rsrcource_groups_h__
-#define __rsrcource_groups_h__
+#ifndef __resource_groups_h__
+#define __resource_groups_h__
 
 const unsigned char res_help_groups[] = {
   0x53, 0x65, 0x6c, 0x65, 0x63, 0x74, 0x20, 0x77, 0x68, 0x61, 0x74, 0x20,

--- a/src/resources/help/increment.h
+++ b/src/resources/help/increment.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __rsrcource_increment_h__
-#define __rsrcource_increment_h__
+#ifndef __resource_increment_h__
+#define __resource_increment_h__
 
 const unsigned char res_help_increment[] = {
   0x54, 0x68, 0x65, 0x20, 0x69, 0x6e, 0x63, 0x72, 0x65, 0x6d, 0x65, 0x6e,

--- a/src/resources/help/list_groups.h
+++ b/src/resources/help/list_groups.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __rsrcource_list_groups_h__
-#define __rsrcource_list_groups_h__
+#ifndef __resource_list_groups_h__
+#define __resource_list_groups_h__
 
 const unsigned char res_help_list_groups[] = {
   0x4c, 0x69, 0x73, 0x74, 0x20, 0x61, 0x6c, 0x6c, 0x20, 0x61, 0x76, 0x61,

--- a/src/resources/help/list_increments.h
+++ b/src/resources/help/list_increments.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __rsrcource_list_increments_h__
-#define __rsrcource_list_increments_h__
+#ifndef __resource_list_increments_h__
+#define __resource_list_increments_h__
 
 const unsigned char res_help_list_increments[] = {
   0x4c, 0x69, 0x73, 0x74, 0x20, 0x61, 0x6c, 0x6c, 0x20, 0x61, 0x76, 0x61,

--- a/src/resources/help/list_transforms.h
+++ b/src/resources/help/list_transforms.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __rsrcource_list_transforms_h__
-#define __rsrcource_list_transforms_h__
+#ifndef __resource_list_transforms_h__
+#define __resource_list_transforms_h__
 
 const unsigned char res_help_list_transforms[] = {
   0x4c, 0x69, 0x73, 0x74, 0x20, 0x61, 0x6c, 0x6c, 0x20, 0x61, 0x76, 0x61,

--- a/src/resources/help/output.h
+++ b/src/resources/help/output.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __rsrcource_output_h__
-#define __rsrcource_output_h__
+#ifndef __resource_output_h__
+#define __resource_output_h__
 
 const unsigned char res_help_output[] = {
   0x54, 0x68, 0x65, 0x20, 0x66, 0x69, 0x6c, 0x65, 0x20, 0x74, 0x6f, 0x20,

--- a/src/resources/help/prefix.h
+++ b/src/resources/help/prefix.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __rsrcource_prefix_h__
-#define __rsrcource_prefix_h__
+#ifndef __resource_prefix_h__
+#define __resource_prefix_h__
 
 const unsigned char res_help_prefix[] = {
   0x41, 0x20, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x20, 0x74, 0x68, 0x61,

--- a/src/resources/help/transform.h
+++ b/src/resources/help/transform.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __rsrcource_transform_h__
-#define __rsrcource_transform_h__
+#ifndef __resource_transform_h__
+#define __resource_transform_h__
 
 const unsigned char res_help_transform[] = {
   0x53, 0x65, 0x6c, 0x65, 0x63, 0x74, 0x20, 0x61, 0x20, 0x74, 0x72, 0x61,

--- a/src/resources/help/verbose.h
+++ b/src/resources/help/verbose.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __rsrcource_verbose_h__
-#define __rsrcource_verbose_h__
+#ifndef __resource_verbose_h__
+#define __resource_verbose_h__
 
 const unsigned char res_help_verbose[] = {
   0x45, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x20, 0x76, 0x65, 0x72, 0x62, 0x6f,

--- a/src/resources/help/year.h
+++ b/src/resources/help/year.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __rsrcource_year_h__
-#define __rsrcource_year_h__
+#ifndef __resource_year_h__
+#define __resource_year_h__
 
 const unsigned char res_help_year[] = {
   0x54, 0x68, 0x65, 0x20, 0x79, 0x65, 0x61, 0x72, 0x20, 0x75, 0x73, 0x65,


### PR DESCRIPTION
Fix for issue #2.

### Description of the change

Removed typo in `make-xxd` script and re-ran, which fixes all typos in resource headers.

### Benefits

Less typos!

### Possible drawbacks

None.

###
@asmodai Please review this.

